### PR TITLE
Add npm shortcuts for easy installation/startup of wallboarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,21 @@ Install Bower dependencies: (e.g. jquery)
 ./node_modules/bower/bin/bower install
 ```
 
+Install MongoDB (Mac OSX with Homebrew installed only)
+```
+npm run mongodb:install
+```
+
 ## Usage
 
 Start Wallboarder:
 ```
-./node_modules/forever/bin/forever start server.js
+npm start
 ```
 
 Stop Wallboarder:
 ```
-./node_modules/forever/bin/forever stop server.js
+npm stop
 ```
 
 Visit in your browser:```http://<your-ip-or-domain>:8081``` e.g ```http://localhost:8081```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "wallboarder",
   "description": "Wallboarder - WYSIWYG Editor for Wallboards",
-  "authors": [
-    "James Harding <james@jamesharding.me>"
-  ],
+  "author": "James Harding <james@jamesharding.me>",
   "license": "MIT",
   "repository": "https://github.com/hjamesw93/wallboarder",
   "main": "server.js",
+  "version": "0.0.1",
   "dependencies": {
     "body-parser": "~1.0.1",
     "bower": "^1.7.7",
@@ -18,5 +17,13 @@
     "mongodb": "^2.1.0",
     "mongoose": "^4.4.7",
     "socket.io": "^1.4.5"
+  },
+  "scripts" : {
+    "start": "npm run mongod:start && forever start server.js",
+    "stop": "npm run mongod:stop && forever stop server.js",
+    "forever": "forever",
+    "mongod:install": "brew install mongodb",
+    "mongod:start": "mongod --config /usr/local/etc/mongod.conf &",
+    "mongod:stop": "pkill mongod"
   }
 }


### PR DESCRIPTION
To make life a little easier on our brains, this PR utilises npm scripts to keep startup and installation scripts simple (or that's the intended idea :smile: )

`npm start`: start the mongod service and start the server
`npm stop`: stop the mongod service and stop the server
`mongod:install`: install mongodb via homebrew (only supported method for now)
`mongod:start`: start mongodb with default settings
`mongod:stop`: stop mongodb using pkill
