### PR TITLE
consolidate package libraries to just use npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,24 +6,41 @@
   "repository": "https://github.com/hjamesw93/wallboarder",
   "main": "server.js",
   "version": "0.4.2",
+  "engines": {
+    "node": "5.10.1"
+  },
   "dependencies": {
     "body-parser": "~1.0.1",
-    "bower": "^1.7.7",
+    "bootstrap": "^3.3.6",
+    "datatables-bootstrap3-plugin": "^0.4.0",
     "express": "~4.0.0",
+    "font-awesome": "^4.5.0",
     "forever": "^0.15.1",
+    "install": "^0.6.1",
     "jade": "^1.11.0",
+    "jquery": "^2.2.2",
+    "jquery-ui": "^1.10.5",
     "jsonfile": "^2.2.3",
     "kerberos": "0.0.17",
     "mongodb": "^2.1.0",
     "mongoose": "^4.4.7",
-    "socket.io": "^1.4.5"
+    "socket.io": "^1.4.5",
+    "socket.io-client": "^1.4.5",
+    "tinycolorpicker": "^0.9.5"
   },
-  "scripts" : {
+  "scripts": {
     "start": "npm run mongod:start && forever start server.js",
     "stop": "npm run mongod:stop && forever stop server.js",
     "forever": "forever",
     "mongod:install": "brew install mongodb",
     "mongod:start": "mongod --config /usr/local/etc/mongod.conf &",
-    "mongod:stop": "pkill mongod"
+    "mongod:stop": "pkill mongod",
+    "install": "napa"
+  },
+  "napa": {
+    "jquery-tabledit": "markcell/jquery-tabledit#v1.2.3"
+  },
+  "devDependencies": {
+    "napa": "^2.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -18,8 +18,14 @@ app.use('/', routes);
 server.listen(config.app.port, config.app.host);
 
 app.use(express.static('public'));
-app.use('/components', express.static('bower_components'));
-
+app.use('/components/jquery', express.static('node_modules/jquery'));
+app.use('/components/jquery-ui', express.static('node_modules/jquery-ui'));
+app.use('/components/jquery-tabledit', express.static('node_modules/jquery-tabledit'));
+app.use('/components/bootstrap/', express.static('node_modules/bootstrap'));
+app.use('/components/socket.io-client/', express.static('node_modules/socket.io-client'));
+app.use('/components/bootstrap/dist/css/', express.static('node_modules/bootstrap/dist/css/'));
+app.use('/components/font-awesome/', express.static('node_modules/font-awesome/'));
+app.use('/components/datatables-bootstrap3-plugin/', express.static('node_modules/datatables-bootstrap3-plugin'));
 
 var editing = false;
 var c_client = "";

--- a/views/index.jade
+++ b/views/index.jade
@@ -5,7 +5,7 @@ html
 
     //requirejs support coming shortly, see: try-requirejs
     script(src="/components/jquery/dist/jquery.min.js")
-    script(src="/components/jquery-ui/jquery-ui.min.js")
+    script(src="//code.jquery.com/ui/1.11.4/jquery-ui.min.js")
     script(src="/components/jquery-tabledit/jquery.tabledit.min.js")
     script(src="/jquery.tinycolorpicker.js")
     script(src="/components/bootstrap/js/collapse.js")

--- a/views/styles.jade
+++ b/views/styles.jade
@@ -1,5 +1,5 @@
 
-link(rel="stylesheet" href="/components/jquery-ui/themes/base/jquery-ui.min.css")
+link(rel="stylesheet" href="/components/jquery-ui/themes/base/minified/jquery-ui.min.css")
 link(rel="stylesheet" href="/components/bootstrap/dist/css/bootstrap.min.css")
 link(rel="stylesheet" href="/components/font-awesome/css/font-awesome.min.css")
 link(rel="stylesheet" href="/main.css")


### PR DESCRIPTION
This is currently work in progress to hopefully modularise the code. This will resolve #13 upon merge. 
Removing bower will allow 3rd party dependencies to be managed in one place (package.json)

One small issue jQuery UI is currently being loaded via CDN (a bit different to everything else going on). We'll probably have to resolve this :wink: 

Additionally there's a few source mappings in server.js that we can tidy up at a later date. 

@hjamesw93 please give it a test to make sure existing functionality is working before merging into master - couldn't find any console errors and things seemed to work but you're probably know the app much better than me!

Cheers! 

![image](https://cloud.githubusercontent.com/assets/8005124/14367583/b4d9b7e2-fd10-11e5-8413-c763eeae033d.png)
